### PR TITLE
fix. 스타일북 > 하단 indicators 첫번째 페이지일 경우 애니메이션 수정

### DIFF
--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/StyleBook.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/StyleBook.kt
@@ -88,9 +88,13 @@ fun StyleBookScreen() {
                 StyleBookItem(item = styleBooks[page % styleBooks.size], pageOffset = pageOffset, alphaOffset = (1f - alphaOffset.coerceIn(0f, 1f)))
             }
         }
-        Spacer(modifier = Modifier.fillMaxWidth().size(12.dp))
+        Spacer(modifier = Modifier
+            .fillMaxWidth()
+            .size(12.dp))
         StyleBookIndicator(pageOffset = pagerState.currentPageOffsetFraction, currentPage = (pagerState.currentPage % styleBooks.size) + 1, pageSize = styleBooks.size)
-        Spacer(modifier = Modifier.fillMaxWidth().size(24.dp))
+        Spacer(modifier = Modifier
+            .fillMaxWidth()
+            .size(24.dp))
         ContentsDivider()
     }
 }
@@ -152,8 +156,13 @@ fun StyleBookItem(item: StyleBook, pageOffset: Float, alphaOffset: Float) {
 
 @Composable
 fun StyleBookIndicator(pageOffset: Float, currentPage: Int, pageSize: Int) {
+    val progressTargetValue = when {
+        ((pageOffset + currentPage) / pageSize) > 1.0f -> ((pageOffset + currentPage) / pageSize) - 1.0f
+        else -> ((pageOffset + currentPage) / pageSize)
+    }.coerceIn(0f .. 1f)
+
     val animatedProgress = animateFloatAsState(
-        targetValue = ((pageOffset + currentPage) / pageSize).coerceIn(0f .. 1f),
+        targetValue = progressTargetValue,
         label = ""
     ).value
 


### PR DESCRIPTION
### 작업 내용
1. 스타일북 > 하단 indicators 애니메이션 수정

### 작업 화면
- AS-IS
https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/94809e79-76e5-45cf-98c0-6d4e431dcf15

- TO-BE
https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/69d99bbc-ff13-4a76-91da-1d1d256ea72e

### 참고사항
- ((pageOffset + currentPage) / pageSize) 값의 경우 pageSize 보다 커질 경우 1.0f 보다 큰 값이 나오게 되어 coerceIn 에서 1.0f로 값이 고정된 현상
- 추가적으로 currentPage 또한 pagerState.currentPageOffsetFraction 값이 0.5f 보다 커야 다음 페이지 인덱스를 가르키게 되므로 발생했던 부자연스러움 
<img width="330" alt="스크린샷 2024-01-12 오후 6 37 38" src="https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/3c675e2d-47b1-44b0-b82f-e20eb12d5b71">

~~~kotlin
// 수정한 ProgressValue
    val progressTargetValue = when {
        ((pageOffset + currentPage) / pageSize) > 1.0f -> ((pageOffset + currentPage) / pageSize) - 1.0f
        else -> ((pageOffset + currentPage) / pageSize)
    }.coerceIn(0f .. 1f)

// 기존 ProgressValue
    val animatedProgress = animateFloatAsState(
        targetValue = ((pageOffset + currentPage) / pageSize).coerceIn(0f .. 1f),
        label = ""
    ).value
~~~


