### PR TITLE
폴더블폰 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,11 +42,15 @@
         android:theme="@style/Theme.Compose_study"
         tools:targetApi="31"
         android:usesCleartextTraffic="true"
-        android:hardwareAccelerated="true">
+        android:hardwareAccelerated="true"
+        android:resizeableActivity="false">
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:minAspectRatio="1.8"
+            android:screenOrientation="portrait"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@style/Theme.Compose_study">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,38 +23,40 @@
         android:name="android.hardware.camera"
         android:required="false" />
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:name=".di.ApplicationClass"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:resizeableActivity="false"
         android:supportsRtl="true"
         android:theme="@style/Theme.Compose_study"
-        tools:targetApi="31"
         android:usesCleartextTraffic="true"
-        android:hardwareAccelerated="true"
-        android:resizeableActivity="false">
+        tools:targetApi="31">
+
         <activity
             android:name=".ui.MainActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
             android:exported="true"
             android:label="@string/app_name"
             android:minAspectRatio="1.8"
             android:screenOrientation="portrait"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-            android:theme="@style/Theme.Compose_study">
+            android:theme="@style/Theme.Compose_study"
+            tools:ignore="LockedOrientationActivity,RedundantLabel">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
### 작업 내용
1. 폴더블폰 화면 대응 [5decdd4]
2. Manifest 코드 정리 [c70775d]

### 고민 사항
~~~kotlin
## Problem1 : 폴더블에서 화면 비율이 너무 크게 나오는 경우에 어떻게 대응을 할것인가? ##
Answer. 두가지 방법이 존재한다.
1. 멀티 윈도우 사용한다.
2. 에뮬레이터 띄우듯이 화면 비율을 유지한다. (PC에서 모바일 애뮬레이터 띄우는 느낌)

## Problem2 : 멀티 윈도우를 대응할 만한 가치가 있는가? ##
Answer. 
1. 유저 사용율을 살펴보고 정의를 해야할 것 같다.(태블릿의 사용빈도가 적어도 10% 이상이라면 멀티 윈도우는 고려해볼만한 사항이다.)
2. 물론 멀티 윈도우로 대응하는 경우 그에 따른 Ui는 나와야 한다. (적어도 일부 화면에 대해서라도)

## Problem3 : 현재 대응한 것 처럼 비율을 짜르는 방식을 하면 어떤점이 좋은가? ##
Answer.
1. 적어도 폴더블폰에서 사용시 유저에게 배너가 한 화면을 차지하는 것 처럼 보이는 경우는 없어진다.
2. 다만, 유저가 클릭을 할경우 좁아진 Width 만큼 클릭에 제약은 생긴다.

## Problem4 : 폴더블에 대한 대응을 함으로써 발생하는 SideEffect는 없는가? ##
Answer.
1. 존재한다. 그러나 해당 내용은 코드를 살펴보면서 진행을 해야할 사항이다. (있을 수도.. 없을 수도..)
2. 최적화를 잘하고 해당 코드에 대한 대응은 필요한 사항이다.
최적화 참고 : https://developer.android.com/guide/topics/large-screens/large-screen-compatibility-mode?hl=ko
~~~

### 작업 화면
- 기존 폴더블
<img width="300" alt="스크린샷 2024-02-12 오후 10 16 00" src="https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/bd75b760-dc50-4a1c-a903-ec79d42c89d1">

- 폴더블 대응
<img width="300" alt="스크린샷 2024-02-12 오후 10 14 58" src="https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/cc1d53f6-c6dd-433b-9faa-eb423cddd3ed">

- 기존 폴더블

https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/4b3ec4fa-0eb8-4462-acc6-c8fe69164fe9

- 폴더블 대응

https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/3663a0d3-ee32-4688-8ecc-0cdd99f95c20