### PR TITLE
[폴더블] 폴더블 대응 Multi - Window 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.2.0'
-    implementation "androidx.compose.material3:material3:1.0.1"
+    implementation "androidx.compose.material3:material3:1.2.0"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,10 @@ dependencies {
     // TwoPane (Multi-Windows)
     def adaptive = "0.34.0"
     implementation("com.google.accompanist:accompanist-adaptive:$adaptive")
+
+    // WindowSize
+    def windowSize = "1.2.0"
+    implementation("androidx.compose.material3:material3-window-size-class:$windowSize")
 }
 kapt {
     correctErrorTypes true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,10 @@ dependencies {
 
     // Compose
     implementation("androidx.compose.foundation:foundation:1.4.0-beta02")
+
+    // TwoPane (Multi-Windows)
+    def adaptive = "0.34.0"
+    implementation("com.google.accompanist:accompanist-adaptive:$adaptive")
 }
 kapt {
     correctErrorTypes true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,10 +51,8 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
             android:exported="true"
             android:label="@string/app_name"
-            android:minAspectRatio="1.8"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.Compose_study"
-            tools:ignore="LockedOrientationActivity,RedundantLabel">
+            tools:ignore="RedundantLabel">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/example/compose_study/ui/Navigation.kt
+++ b/app/src/main/java/com/example/compose_study/ui/Navigation.kt
@@ -98,7 +98,12 @@ fun NavigationGraph(
             VibrateScreen()
         }
         composable(BottomNavItem.Foldable.screenRoute) {
-            FoldableScreen()
+            FoldableScreen(
+                toDetail = {
+                    setValue(it)
+                    navController.navigate(DETAIL)
+                }
+            )
         }
         composable(PHOTO) {
             PhotoScreen(

--- a/app/src/main/java/com/example/compose_study/ui/Navigation.kt
+++ b/app/src/main/java/com/example/compose_study/ui/Navigation.kt
@@ -16,6 +16,7 @@ import com.example.compose_study.ui.screen.detail.DetailScreen
 import com.example.compose_study.ui.screen.dialog.CustomDialogScreen
 import com.example.compose_study.ui.screen.draw.DrawScreen
 import com.example.compose_study.ui.screen.feature.FeatureScreen
+import com.example.compose_study.ui.screen.foldable.FoldableScreen
 import com.example.compose_study.ui.screen.home.HomeScreen
 import com.example.compose_study.ui.screen.more.More
 import com.example.compose_study.ui.screen.permission.PermissionScreen
@@ -95,6 +96,9 @@ fun NavigationGraph(
         }
         composable(BottomNavItem.Vibrate.screenRoute) {
             VibrateScreen()
+        }
+        composable(BottomNavItem.Foldable.screenRoute) {
+            FoldableScreen()
         }
         composable(PHOTO) {
             PhotoScreen(

--- a/app/src/main/java/com/example/compose_study/ui/Utils.kt
+++ b/app/src/main/java/com/example/compose_study/ui/Utils.kt
@@ -40,6 +40,11 @@ fun Loading() {
 }
 
 @Composable
+fun Empty() {
+    Box(modifier = Modifier.fillMaxSize().background(Color.White.copy(0.1f)),)
+}
+
+@Composable
 fun ScrollToTopButton(onClick: () -> Unit, modifier: Modifier) {
     Column(
         modifier = modifier

--- a/app/src/main/java/com/example/compose_study/ui/item/BottomNavItem.kt
+++ b/app/src/main/java/com/example/compose_study/ui/item/BottomNavItem.kt
@@ -16,6 +16,7 @@ sealed class BottomNavItem(
     object Permission : BottomNavItem(title = R.string.permission, icon = R.drawable.ic_permission, screenRoute = PERMISSION)
 	object Draw : BottomNavItem(title = R.string.draw, icon = R.drawable.ic_draw, screenRoute = DRAW)
 	object Vibrate : BottomNavItem(title = R.string.vibrate, icon = R.drawable.ic_vibrate, screenRoute = VIBRATE)
+    object Foldable : BottomNavItem(title = R.string.foldable, icon = R.drawable.ic_foldable, screenRoute = FOLDABLE)
 }
 
 const val PAGING = "PAGING"
@@ -31,3 +32,4 @@ const val PERMISSION = "PERMISSION"
 const val DRAW = "DRAW"
 const val VIBRATE = "VIBRATE"
 const val PHOTO = "PHOTO"
+const val FOLDABLE = "FOLDABLE"

--- a/app/src/main/java/com/example/compose_study/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/detail/DetailScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -18,12 +19,12 @@ import com.example.compose_study.ui.screen.PhotoLazyGrid
 
 @Composable
 fun DetailScreen(
-    id: String,
-    toBack: () -> Unit,
+    id: String? = null,
+    toBack: () -> Unit = {},
     viewModel: DetailViewModel = hiltViewModel()
 ) {
-    viewModel.getPhoto(id = id)
-    val photo = viewModel.photoState.collectAsState()
+    id?.let { viewModel.getPhoto(id = it) }
+    val photo by viewModel.photoState.collectAsState()
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -38,24 +39,30 @@ fun DetailScreen(
             )
         }
     ) { paddingValues ->
-        if(photo.value == null) {
-            Loading()
-        } else {
-            Column(modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)) {
+        if (photo == null) Loading()
 
-                ImageBigSize(url = photo.value!!.url)
+        photo?.let {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            ) {
+                ImageBigSize(url = it.url)
                 Text(
-                    modifier = Modifier.fillMaxWidth().padding(16.dp, 8.dp),
-                    text = photo.value!!.author
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp, 8.dp),
+                    text = it.author
                 )
                 Text(
-                    modifier = Modifier.fillMaxWidth().padding(16.dp, 8.dp),
-                    text = photo.value!!.download_url
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp, 8.dp),
+                    text = it.download_url
                 )
-
-                PhotoLazyGrid(photoList = viewModel.photos, onClick = { viewModel.getPhoto(id = it) })
+                PhotoLazyGrid(
+                    photoList = viewModel.photos,
+                    onClick = { viewModel.getPhoto(id = it) })
             }
         }
     }

--- a/app/src/main/java/com/example/compose_study/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/detail/DetailScreen.kt
@@ -1,9 +1,11 @@
 package com.example.compose_study.ui.screen.detail
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -13,6 +15,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.compose_study.model.Photo
+import com.example.compose_study.ui.Empty
 import com.example.compose_study.ui.ImageBigSize
 import com.example.compose_study.ui.Loading
 import com.example.compose_study.ui.screen.PhotoLazyGrid
@@ -23,7 +27,9 @@ fun DetailScreen(
     toBack: () -> Unit = {},
     viewModel: DetailViewModel = hiltViewModel()
 ) {
-    id?.let { viewModel.getPhoto(id = it) }
+    if (!id.isNullOrBlank()) {
+        viewModel.getPhoto(id)
+    }
     val photo by viewModel.photoState.collectAsState()
 
     Scaffold(
@@ -39,31 +45,45 @@ fun DetailScreen(
             )
         }
     ) { paddingValues ->
-        if (photo == null) Loading()
-
-        photo?.let {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-            ) {
-                ImageBigSize(url = it.url)
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp, 8.dp),
-                    text = it.author
-                )
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp, 8.dp),
-                    text = it.download_url
-                )
-                PhotoLazyGrid(
-                    photoList = viewModel.photos,
-                    onClick = { viewModel.getPhoto(id = it) })
-            }
+        if (id == null) {
+            Empty()
+            viewModel.getEmptyView()
         }
+        id?.let {
+            if (photo == null) Loading()
+        }
+        photo?.let {
+            PhotoDetail(paddingValues = paddingValues, photo = photo!!)
+        }
+    }
+}
+
+@Composable
+fun PhotoDetail(
+    paddingValues: PaddingValues,
+    photo: Photo,
+    viewModel: DetailViewModel = hiltViewModel()
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+    ) {
+        ImageBigSize(url = photo.url)
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp, 8.dp),
+            text = photo.author
+        )
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp, 8.dp),
+            text = photo.download_url
+        )
+        PhotoLazyGrid(
+            photoList = viewModel.photos,
+            onClick = { viewModel.getPhoto(id = it) })
     }
 }

--- a/app/src/main/java/com/example/compose_study/ui/screen/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/detail/DetailViewModel.kt
@@ -32,4 +32,10 @@ class DetailViewModel @Inject constructor(
             _photoState.value = getPhotoUseCase.invoke(id = id)
         }
     }
+
+    fun getEmptyView() {
+        baseViewModelScope.launch {
+            _photoState.value = null
+        }
+    }
 }

--- a/app/src/main/java/com/example/compose_study/ui/screen/dialog/BottomSheetScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/dialog/BottomSheetScreen.kt
@@ -91,7 +91,7 @@ fun BottomSheetScreen(
                     }
                 }
 
-                if(showDialog) {
+                if (showDialog) {
                     CustomDialogScreen(
                         onDismiss = {
                             showDialog = false

--- a/app/src/main/java/com/example/compose_study/ui/screen/dialog/BottomSheetScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/dialog/BottomSheetScreen.kt
@@ -83,7 +83,7 @@ fun BottomSheetScreen(
                         onClick = {
                             coroutineScope.launch {
                                 if (modalSheetState.isVisible) modalSheetState.hide()
-                                else modalSheetState.animateTo(ModalBottomSheetValue.Expanded)
+                                else modalSheetState.show()
                             }
                         },
                     ) {

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/EventBanner.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/EventBanner.kt
@@ -47,7 +47,7 @@ fun EventBannerScreen() {
     val banner3 = EventBanner(bannerUri = "https://png.pngtree.com/thumb_back/fh260/background/20201019/pngtree-abstract-black-friday-event-banner-with-colorful-ornament-image_424224.jpg")
     val banners = listOf(banner1, banner2, banner3)
 
-    val pagerState = rememberPagerState(initialPage = banners.infiniteLoopInitPage())
+    val pagerState = rememberPagerState(initialPage = banners.infiniteLoopInitPage(), pageCount = { Int.MAX_VALUE })
     val isDragged by pagerState.interactionSource.collectIsDraggedAsState()
     var nextPage by remember { mutableStateOf(banners.infiniteLoopInitPage()) }
     var pageSize by remember { mutableStateOf(IntSize.Zero) }
@@ -71,7 +71,6 @@ fun EventBannerScreen() {
         EventBannerTitle()
         HorizontalPager(
             state = pagerState,
-            pageCount = Int.MAX_VALUE,
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             contentPadding = PaddingValues(horizontal = 12.dp)

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/StyleBook.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/StyleBook.kt
@@ -47,7 +47,7 @@ import kotlin.math.absoluteValue
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun StyleBookScreen() {
-    val pagerState = rememberPagerState(initialPage = styleBooks.infiniteLoopInitPage())
+    val pagerState = rememberPagerState(initialPage = styleBooks.infiniteLoopInitPage(), pageCount = { Int.MAX_VALUE })
     val isDragged by pagerState.interactionSource.collectIsDraggedAsState()
     var nextPage by remember { mutableStateOf(styleBooks.infiniteLoopInitPage()) }
 
@@ -73,7 +73,6 @@ fun StyleBookScreen() {
         StyleBookTitle()
         HorizontalPager(
             state = pagerState,
-            pageCount = Int.MAX_VALUE,
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) { page ->

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/TodayStyleBook.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/TodayStyleBook.kt
@@ -40,7 +40,7 @@ import kotlin.math.absoluteValue
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TodayStyleBookScreen() {
-    val pagerState = rememberPagerState(initialPage = styleBooks.infiniteLoopInitPage())
+    val pagerState = rememberPagerState(initialPage = styleBooks.infiniteLoopInitPage(), pageCount = { Int.MAX_VALUE })
 
 
     Column(
@@ -51,7 +51,6 @@ fun TodayStyleBookScreen() {
         TodayStyleBookTitle()
         HorizontalPager(
             state = pagerState,
-            pageCount = Int.MAX_VALUE,
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             contentPadding = PaddingValues(end = 40.dp, start = 40.dp)

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/TopBanner.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/TopBanner.kt
@@ -75,7 +75,7 @@ fun TopBannerScreen(
 @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun TopBannerSlider(banners: List<TopBanner>) {
-    val pagerState = rememberPagerState(initialPage = banners.infiniteLoopInitPage())
+    val pagerState = rememberPagerState(initialPage = banners.infiniteLoopInitPage(), pageCount = { if (banners.size > 1) Int.MAX_VALUE else 1 })
     val isDragged by pagerState.interactionSource.collectIsDraggedAsState()
     var nextPage by remember { mutableStateOf(banners.infiniteLoopInitPage()) }
     var offsetY by remember { mutableStateOf(0f) }
@@ -104,7 +104,6 @@ fun TopBannerSlider(banners: List<TopBanner>) {
                     false
                 }.onSizeChanged { pageSize = it },
             state = pagerState,
-            pageCount = if (banners.size > 1) Int.MAX_VALUE else 1
         ) { page ->
             val pageOffset = pagerState.offsetForPage(page)
             val endOffset = pagerState.endOffsetForPage(page)

--- a/app/src/main/java/com/example/compose_study/ui/screen/foldable/FoldableScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/foldable/FoldableScreen.kt
@@ -1,0 +1,32 @@
+package com.example.compose_study.ui.screen.foldable
+
+import android.app.Activity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.example.compose_study.ui.screen.detail.DetailScreen
+import com.example.compose_study.ui.screen.home.HomeScreen
+import com.google.accompanist.adaptive.FoldAwareConfiguration
+import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
+import com.google.accompanist.adaptive.TwoPane
+import com.google.accompanist.adaptive.calculateDisplayFeatures
+
+@Composable
+fun FoldableScreen() {
+    val activity = LocalContext.current as Activity
+    TwoPane(
+        modifier = Modifier.fillMaxSize(),
+        first = {
+            HomeScreen(
+                toDetail = {}
+            )
+        },
+        second = {
+            DetailScreen()
+        },
+        strategy = HorizontalTwoPaneStrategy(splitFraction = 0.5f),
+        displayFeatures = calculateDisplayFeatures(activity),
+        foldAwareConfiguration = FoldAwareConfiguration.HorizontalFoldsOnly
+    )
+}

--- a/app/src/main/java/com/example/compose_study/ui/screen/foldable/FoldableScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/foldable/FoldableScreen.kt
@@ -3,30 +3,55 @@ package com.example.compose_study.ui.screen.foldable
 import android.app.Activity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.example.compose_study.ui.screen.detail.DetailScreen
 import com.example.compose_study.ui.screen.home.HomeScreen
+import com.example.compose_study.utils.isWideDisplay
 import com.google.accompanist.adaptive.FoldAwareConfiguration
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
 import com.google.accompanist.adaptive.calculateDisplayFeatures
 
 @Composable
-fun FoldableScreen() {
+fun FoldableScreen(
+    toDetail: (id: String) -> Unit
+) {
     val activity = LocalContext.current as Activity
+    val showTwoDisplay = isWideDisplay(activity = activity)
+
+    when (showTwoDisplay) {
+        true -> FoldableTwoScreen(activity = activity)
+        false -> HomeScreen(toDetail = toDetail)
+    }
+}
+
+@Composable
+fun FoldableTwoScreen(
+    activity: Activity = LocalContext.current as Activity
+) {
+    var detailId by remember { mutableStateOf<String?>(null) }
     TwoPane(
         modifier = Modifier.fillMaxSize(),
         first = {
             HomeScreen(
-                toDetail = {}
+                toDetail = { detailId = if (detailId == it) null else it }
             )
         },
         second = {
-            DetailScreen()
+            DetailScreen(
+                id = detailId,
+                toBack = { detailId = null }
+            )
         },
         strategy = HorizontalTwoPaneStrategy(splitFraction = 0.5f),
         displayFeatures = calculateDisplayFeatures(activity),
         foldAwareConfiguration = FoldAwareConfiguration.HorizontalFoldsOnly
     )
 }
+
+

--- a/app/src/main/java/com/example/compose_study/ui/screen/foldable/FoldableViewModel.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/foldable/FoldableViewModel.kt
@@ -1,0 +1,39 @@
+package com.example.compose_study.ui.screen.foldable
+
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.example.compose_study.domain.GetPhotoListUseCase
+import com.example.compose_study.model.Photo
+import com.example.compose_study.ui.BaseViewModel
+import com.example.compose_study.ui.paging_source.createPhotoPager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FoldableViewModel @Inject constructor(
+    getPhotoListUseCase: GetPhotoListUseCase
+) : BaseViewModel() {
+
+    val photos: Flow<PagingData<Photo>> = createPhotoPager(getPhotoListUseCase = getPhotoListUseCase)
+        .flow.cachedIn(baseViewModelScope)
+
+    private val _searchState: MutableSharedFlow<String> = MutableSharedFlow()
+    val searchState: SharedFlow<String> = _searchState.asSharedFlow()
+
+    private val _scrollToTopEvent: MutableSharedFlow<Unit> = MutableSharedFlow()
+    val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
+
+    fun searchAuthor(text: String) {
+        baseViewModelScope.launch {
+            _searchState.emit(text)
+        }
+    }
+
+    fun scrollToTop() {
+        baseViewModelScope.launch {
+            _scrollToTopEvent.emit(Unit)
+        }
+    }
+}

--- a/app/src/main/java/com/example/compose_study/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,9 +28,11 @@ fun HomeScreen(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(modifier = Modifier
-                .fillMaxWidth()
-                .weight(8f)) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(8f)
+            ) {
                 PhotoLazyColumn(photoList = viewModel.photos, onClick = { toDetail(it) })
             }
             TextFieldItem(viewModel)

--- a/app/src/main/java/com/example/compose_study/ui/screen/main/BottomNavigateionScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/main/BottomNavigateionScreen.kt
@@ -28,7 +28,8 @@ fun BottomNavigationScreen(navController: NavController) {
         BottomNavItem.Feature,
         BottomNavItem.Permission,
         BottomNavItem.Draw,
-        BottomNavItem.Vibrate
+        BottomNavItem.Vibrate,
+        BottomNavItem.Foldable
     )
     BottomNavigation(
         backgroundColor = Color.Blue,

--- a/app/src/main/java/com/example/compose_study/utils/isWideDisplay.kt
+++ b/app/src/main/java/com/example/compose_study/utils/isWideDisplay.kt
@@ -1,0 +1,25 @@
+package com.example.compose_study.utils
+
+import android.app.Activity
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Composable
+fun isWideDisplay(
+    activity: Activity = LocalContext.current as Activity,
+): Boolean {
+
+    val windowSizeClass = calculateWindowSizeClass(activity)
+    val showTwoPaneLayout: Boolean by remember(windowSizeClass) {
+        derivedStateOf { windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium }
+    }
+
+    return showTwoPaneLayout
+}

--- a/app/src/main/res/drawable/ic_foldable.xml
+++ b/app/src/main/res/drawable/ic_foldable.xml
@@ -1,0 +1,12 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,3h-3c0,-1.43 -1.47,-2.4 -2.79,-1.84l-3,1.29C10.48,2.76 10,3.49 10,4.29V19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V5C22,3.9 21.1,3 20,3zM20,19h-5.33l1.12,-0.48C16.52,18.2 17,17.48 17,16.68V5h3V19z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2,3h2v2h-2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2,19h2v2h-2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2,15h2v2h-2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2,11h2v2h-2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2,7h2v2h-2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M6,3h2v2h-2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M6,19h2v2h-2z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="draw">Draw</string>
     <string name="vibrate">Vibrate</string>
     <string name="photo">Photo</string>
+    <string name="foldable">Foldable</string>
 
     <string name="title_profile">프로필</string>
     <string name="title_notification">공지사항</string>


### PR DESCRIPTION
### 작업 내용
1. 폴더블 대응 > 비율 강제 하던 내용 제거
2. 폴더블 대응 > Multi - Window 기능 추가

### 작업 화면
https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/bec1beec-370d-4930-9cc7-0cccddbe9af3

### 참고사항
~~~kotlin
// fun isWideDisplay는 폴더블 폰이 펴졌는지, 접혔는지에 대한 판별을 위한 함수
@Composable
fun FoldableScreen(
    toDetail: (id: String) -> Unit
) {
    val activity = LocalContext.current as Activity
    val showTwoDisplay = isWideDisplay(activity = activity)

    when (showTwoDisplay) {
        true -> FoldableTwoScreen(activity = activity)
        false -> HomeScreen(toDetail = toDetail)
    }
}
~~~

## TO-DO
1. 폴더블 비율 유저가 지정할 수 있도록 수정