### PR TITLE
[마케팅을 증진을 위한 알림] 주기적인 로컬 알림 기능 적용하기 - 시간 편차 존재

### DIFF
--- a/app/src/main/java/com/example/compose_study/ui/screen/permission/PermissionScreen.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/permission/PermissionScreen.kt
@@ -37,8 +37,10 @@ import com.example.compose_study.utils.behavior.openAppSettings
 import com.example.compose_study.utils.behavior.scheduleNotificationSettings
 import com.example.compose_study.utils.permission.galleyPermission
 import com.example.compose_study.utils.notification.FirebaseMessagingService
+import com.example.compose_study.utils.notification.getExactPushMessage
+import com.example.compose_study.utils.notification.getNonExactPushMessage
 import com.example.compose_study.utils.notification.local.LocalNotificationHelper
-import com.example.compose_study.utils.notification.getTestPushMessage
+import com.example.compose_study.utils.notification.getPushMessage
 import com.example.compose_study.utils.permission.notificationPermission
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
@@ -61,28 +63,39 @@ fun PermissionScreen(
         val areGranted = permissionsMap.values.reduce { acc, next -> acc || next }
         if (areGranted) {
             Toast.makeText(context, "알림 권한을 허용 하였습니다.", Toast.LENGTH_SHORT).show()
-            firebaseMessagingService.sendNotification(message = getTestPushMessage())
+            firebaseMessagingService.sendNotification(message = getPushMessage())
         } else {
             Toast.makeText(context, "알림 권한을 차단 하였습니다.", Toast.LENGTH_SHORT).show()
             openAppSettings(context = context)
         }
     }
 
-    val scheduleNotificationPermissionsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissionsMap ->
+    val exactRepeatNotificationPermissionsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissionsMap ->
         val areGranted = permissionsMap.values.reduce { acc, next -> acc || next }
         when {
             areGranted && alarmManager?.canScheduleExactAlarms() == true -> {
-                Toast.makeText(context, "스케줄 알림 권한을 허용 하였습니다.", Toast.LENGTH_SHORT).show()
-                localNotificationHelper.sendNotification(message = getTestPushMessage())
+                Toast.makeText(context, "정확한 시간 알림 권한을 허용 하였습니다.", Toast.LENGTH_SHORT).show()
+                localNotificationHelper.sendNotification(message = getExactPushMessage())
             }
             areGranted && alarmManager?.canScheduleExactAlarms() == false -> {
-                Toast.makeText(context, "스케줄 알림 권한을 차단 하였습니다.", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "정확한 시간 알림 권한을 허용해주세요.", Toast.LENGTH_SHORT).show()
                 scheduleNotificationSettings(context)
             }
             else -> {
                 Toast.makeText(context, "알림 권한을 차단 하였습니다.", Toast.LENGTH_SHORT).show()
                 openAppSettings(context = context)
             }
+        }
+    }
+
+    val nonExactRepeatNotificationPermissionsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissionsMap ->
+        val areGranted = permissionsMap.values.reduce { acc, next -> acc || next }
+        if (areGranted) {
+            Toast.makeText(context, "알림 권한을 허용 하였습니다.", Toast.LENGTH_SHORT).show()
+            firebaseMessagingService.sendNotification(message = getNonExactPushMessage())
+        } else {
+            Toast.makeText(context, "알림 권한을 차단 하였습니다.", Toast.LENGTH_SHORT).show()
+            openAppSettings(context = context)
         }
     }
 
@@ -170,11 +183,24 @@ fun PermissionScreen(
                 modifier = Modifier
                     .background(color = Color.Black)
                     .padding(vertical = 12.dp, horizontal = 16.dp)
-                    .clickable { scheduleNotificationPermissionsLauncher.launch(notificationPermission) }
+                    .clickable { exactRepeatNotificationPermissionsLauncher.launch(notificationPermission) }
             ) {
                 Text(
                     modifier = Modifier.background(color = Color.Black),
-                    text = "Notification ExactAndAllowWhileIdle",
+                    text = "Repeat Notification (Exact)",
+                    color = Color.White
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp).wrapContentWidth())
+            Surface(
+                modifier = Modifier
+                    .background(color = Color.Black)
+                    .padding(vertical = 12.dp, horizontal = 16.dp)
+                    .clickable { nonExactRepeatNotificationPermissionsLauncher.launch(notificationPermission) }
+            ) {
+                Text(
+                    modifier = Modifier.background(color = Color.Black),
+                    text = "Repeat Notification (Non Exact)",
                     color = Color.White
                 )
             }

--- a/app/src/main/java/com/example/compose_study/utils/notification/PushMessage.kt
+++ b/app/src/main/java/com/example/compose_study/utils/notification/PushMessage.kt
@@ -11,6 +11,7 @@ data class PushMessage(
     val type: Type,
     val typeName: String,
     val soundMode: SoundMode,
+    val timeMode: TimeMode = TimeMode.NON_EXACT,
     val title: String,
     val message: String,
     val imageUrl: String,
@@ -25,6 +26,10 @@ data class PushMessage(
 
     enum class SoundMode {
         NONE, DEFAULT
+    }
+
+    enum class TimeMode {
+        EXACT, NON_EXACT
     }
 
     enum class Type {

--- a/app/src/main/java/com/example/compose_study/utils/notification/PushMessageTest.kt
+++ b/app/src/main/java/com/example/compose_study/utils/notification/PushMessageTest.kt
@@ -2,7 +2,7 @@ package com.example.compose_study.utils.notification
 
 import kotlin.random.Random
 
-internal fun getTestPushMessage(): PushMessage {
+internal fun getPushMessage(): PushMessage {
     val random = Random.nextInt()
     return when (random % 6) {
         0 -> testPushMessage
@@ -15,12 +15,33 @@ internal fun getTestPushMessage(): PushMessage {
     }
 }
 
+internal fun getExactPushMessage(): PushMessage {
+    val random = Random.nextInt()
+    return when (random % 3) {
+        0 -> testPushMessage
+        1 -> testPushMessageWithImage
+        2 -> testPushMessageOnlyImage
+        else -> testPushMessage
+    }
+}
+
+internal fun getNonExactPushMessage(): PushMessage {
+    val random = Random.nextInt()
+    return when (random % 3) {
+        0 -> testPushMessageSoundNone
+        1 -> testPushMessageWithImageSoundNone
+        2 -> testPushMessageOnlyImageSoundNone
+        else -> testPushMessageSoundNone
+    }
+}
+
 private val testPushMessage: PushMessage =
     PushMessage(
         id = "test",
         type = PushMessage.Type.GENERAL,
         typeName = "GENERAL",
         soundMode = PushMessage.SoundMode.DEFAULT,
+        timeMode = PushMessage.TimeMode.EXACT,
         title = "문구 테스트 알림 (Sound Default)",
         message = "테스트 알림이 왔어요~\n기본 테스트 알림이 왔어요~",
         imageUrl = "",
@@ -33,6 +54,7 @@ private val testPushMessageWithImage: PushMessage =
         type = PushMessage.Type.GENERAL,
         typeName = "GENERAL",
         soundMode = PushMessage.SoundMode.DEFAULT,
+        timeMode = PushMessage.TimeMode.EXACT,
         title = "이미지 문구 테스트 알림 (Sound Default)",
         message = "테스트 알림이 왔어요~\n강아지 사진이 있는 테스트 알림이 왔어요~",
         imageUrl = "https://png.pngtree.com/thumb_back/fh260/background/20230609/pngtree-three-puppies-with-their-mouths-open-are-posing-for-a-photo-image_2902292.jpg",
@@ -45,6 +67,7 @@ private val testPushMessageOnlyImage: PushMessage =
         type = PushMessage.Type.GENERAL,
         typeName = "GENERAL",
         soundMode = PushMessage.SoundMode.DEFAULT,
+        timeMode = PushMessage.TimeMode.EXACT,
         title = "이미지 만 있는 테스트 알림 (Sound Default)",
         message = "",
         imageUrl = "https://png.pngtree.com/thumb_back/fh260/background/20230609/pngtree-three-puppies-with-their-mouths-open-are-posing-for-a-photo-image_2902292.jpg",
@@ -57,6 +80,7 @@ private val testPushMessageSoundNone: PushMessage =
         type = PushMessage.Type.GENERAL,
         typeName = "GENERAL",
         soundMode = PushMessage.SoundMode.NONE,
+        timeMode = PushMessage.TimeMode.NON_EXACT,
         title = "문구 테스트 알림 (Sound None)",
         message = "테스트 알림이 왔어요~\n기본 테스트 알림이 왔어요~",
         imageUrl = "",
@@ -69,6 +93,7 @@ private val testPushMessageWithImageSoundNone: PushMessage =
         type = PushMessage.Type.GENERAL,
         typeName = "GENERAL",
         soundMode = PushMessage.SoundMode.NONE,
+        timeMode = PushMessage.TimeMode.NON_EXACT,
         title = "이미지 문구 테스트 알림 (Sound None)",
         message = "테스트 알림이 왔어요~\n강아지 사진이 있는 테스트 알림이 왔어요~",
         imageUrl = "https://png.pngtree.com/thumb_back/fh260/background/20230609/pngtree-three-puppies-with-their-mouths-open-are-posing-for-a-photo-image_2902292.jpg",
@@ -81,6 +106,7 @@ private val testPushMessageOnlyImageSoundNone: PushMessage =
         type = PushMessage.Type.GENERAL,
         typeName = "GENERAL",
         soundMode = PushMessage.SoundMode.NONE,
+        timeMode = PushMessage.TimeMode.NON_EXACT,
         title = "이미지 만 있는 테스트 알림 (Sound None)",
         message = "",
         imageUrl = "https://png.pngtree.com/thumb_back/fh260/background/20230609/pngtree-three-puppies-with-their-mouths-open-are-posing-for-a-photo-image_2902292.jpg",

--- a/app/src/main/java/com/example/compose_study/utils/notification/local/LocalNotificationHelper.kt
+++ b/app/src/main/java/com/example/compose_study/utils/notification/local/LocalNotificationHelper.kt
@@ -40,7 +40,7 @@ class LocalNotificationHelper(val context: Context) {
         }
 
         if (calendar.time < Date()) {
-            calendar.add(Calendar.DATE, 0)
+            calendar.add(Calendar.DATE, 1)
         }
 
         alarmManager?.setExactAndAllowWhileIdle(

--- a/app/src/main/java/com/example/compose_study/utils/notification/local/LocalNotificationHelper.kt
+++ b/app/src/main/java/com/example/compose_study/utils/notification/local/LocalNotificationHelper.kt
@@ -43,10 +43,21 @@ class LocalNotificationHelper(val context: Context) {
             calendar.add(Calendar.DATE, 1)
         }
 
-        alarmManager?.setExactAndAllowWhileIdle(
-            AlarmManager.RTC_WAKEUP,
-            calendar.timeInMillis,
-            pendingIntent
-        )
+        when (message.timeMode) {
+            PushMessage.TimeMode.EXACT -> {
+                alarmManager?.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    calendar.timeInMillis,
+                    pendingIntent
+                )
+            }
+            PushMessage.TimeMode.NON_EXACT -> {
+                alarmManager?.set(
+                    AlarmManager.RTC_WAKEUP,
+                    calendar.timeInMillis,
+                    pendingIntent
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/compose_study/utils/notification/local/NotificationReceiver.kt
+++ b/app/src/main/java/com/example/compose_study/utils/notification/local/NotificationReceiver.kt
@@ -8,7 +8,9 @@ import android.os.Build
 import android.widget.Toast
 import com.example.compose_study.utils.notification.FirebaseMessagingService
 import com.example.compose_study.utils.notification.PushMessage
-import com.example.compose_study.utils.notification.getTestPushMessage
+import com.example.compose_study.utils.notification.getExactPushMessage
+import com.example.compose_study.utils.notification.getNonExactPushMessage
+import com.example.compose_study.utils.notification.getPushMessage
 
 @Suppress("DEPRECATION")
 class NotificationReceiver : BroadcastReceiver() {
@@ -23,16 +25,20 @@ class NotificationReceiver : BroadcastReceiver() {
         firebaseMessagingService = FirebaseMessagingService(context = context)
         localNotificationHelper = LocalNotificationHelper(context = context)
 
-        val pushMessage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val message = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.getParcelableExtra("PushMessage", PushMessage::class.java)
         } else {
             intent.getParcelableExtra<PushMessage>("PushMessage")
         }
 
-        pushMessage?.let {
+        message?.let {
             if (it.hasContents) {
                 firebaseMessagingService.sendNotification(it)
-                localNotificationHelper.sendNotification(message = getTestPushMessage())
+
+                when (it.timeMode) {
+                    PushMessage.TimeMode.EXACT -> localNotificationHelper.sendNotification(message = getExactPushMessage())
+                    PushMessage.TimeMode.NON_EXACT -> localNotificationHelper.sendNotification(message = getNonExactPushMessage())
+                }
             }
         }
     }


### PR DESCRIPTION
### 작업 내용
1. 주기적인 로컬 알림 기능 추가 (시간 편차 존재)
- 정확한 시간을 요구하는 경우 (Exact Repeat Notification) 아래와 같이 `알림 및 리마인드` 에서 설정을 안하면 사용이 불가능 
- `알림 및 리마인드` 에서 설정 안하게 하는 `setAlarmClock` 도 있긴 한데, 오히려 `setExactAndAllowWhileIdle()`가 더 정확
<img width="200" alt="스크린샷 2024-04-14 22 16 03" src="https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/a3c2f40d-f239-4b90-b267-eb393cb1aba9">

- 시간 편차가 존재하는 경우 (Non Exact Repeat Notification)에는 `알림 및 리마인드` 설정이 안켜저 있어도 사용 가능

### 작업 화면
<img width="300" alt="스크린샷 2024-04-14 22 15 38" src="https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/7083a54f-e8e2-4011-bd3e-a20bc6b060c9">

### 추가 고민
1. 현재는 AlarmManager로 작업을 하였는데, 추후에 WorkManager 로도 만들어보고 어떤 차이점과 장단점이 있는지 비교를 해봐야 할 것 같음
2. 여러 가지 설정의 영향으로 `alarmManger.set()`에 시간 편차가 존재하는데, 이걸 어떻게 하면 없앨 수 있을까?