### PR TITLE
fix. 개인화 카드 > 애니메이션 추가 (fadeIn slideInVertically)

### DIFF
--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -155,6 +156,7 @@ fun ReservationCard() {
         onClick = {}
     ) {
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
@@ -189,7 +191,7 @@ fun ReservationCard() {
                 text = "D-5",
                 fontSize = 15.sp,
                 color = Color.White,
-                modifier = Modifier.width(73.dp),
+                modifier = Modifier.wrapContentWidth(),
                 textAlign = TextAlign.Center
             )
         }
@@ -208,6 +210,7 @@ fun DDayCard() {
         onClick = {}
     ) {
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
@@ -242,7 +245,7 @@ fun DDayCard() {
                 text = "10:56:22",
                 fontSize = 15.sp,
                 color = Color.White,
-                modifier = Modifier.width(73.dp),
+                modifier = Modifier.wrapContentWidth(),
                 textAlign = TextAlign.Center
             )
         }
@@ -261,6 +264,7 @@ fun ReviewCard(isWrite: Boolean) {
         onClick = {}
     ) {
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
@@ -293,7 +297,7 @@ fun ReviewCard(isWrite: Boolean) {
             }
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.width(73.dp)
+                modifier = Modifier.wrapContentWidth()
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.ic_review),
@@ -325,6 +329,7 @@ fun ReReservationCard(isFemale: Boolean) {
         onClick = {}
     ) {
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
@@ -341,7 +346,7 @@ fun ReReservationCard(isFemale: Boolean) {
             ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    text = "여성 디자인컷",
+                    text = message,
                     fontSize = 15.sp,
                     color = Color.Black
                 )
@@ -381,6 +386,7 @@ fun FavoriteCard(type: FavoriteType) {
         onClick = {}
     ) {
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
@@ -68,7 +68,7 @@ fun QuickCardScreen(
 
 @Composable
 fun QuickCard(type: QuickCardType) {
-    when(type) {
+    when (type) {
         QuickCardType.WELCOME -> WelcomeCard()
         QuickCardType.RESERVATION -> ReservationCard()
         QuickCardType.D_DAY -> DDayCard()
@@ -84,15 +84,40 @@ fun QuickCard(type: QuickCardType) {
 
 @Composable
 fun CardMessage(type: QuickCardType) {
-    when(type) {
+    when (type) {
         QuickCardType.WELCOME -> Text(text = "신규고객", color = Color.Black, fontSize = 15.sp)
         QuickCardType.RESERVATION -> Text(text = "-N ~ 1일전", color = Color.Black, fontSize = 15.sp)
         QuickCardType.D_DAY -> Text(text = "24시간 전", color = Color.Black, fontSize = 15.sp)
-        QuickCardType.BEFORE_REVIEW -> Text(text = "시술 후 - 리뷰작성 전", color = Color.Black, fontSize = 15.sp)
-        QuickCardType.AFTER_REVIEW -> Text(text = "시술 후 - 리뷰작성 후", color = Color.Black, fontSize = 15.sp)
-        QuickCardType.RE_RESERVATION_FEMALE -> Text(text = "여성 재예약하기", color = Color.Black, fontSize = 15.sp)
-        QuickCardType.RE_RESERVATION_MALE -> Text(text = "남성 재예약하기", color = Color.Black, fontSize = 15.sp)
-        QuickCardType.MY_DESIGNER -> Text(text = "나의 단골 디자이너", color = Color.Black, fontSize = 15.sp)
+        QuickCardType.BEFORE_REVIEW -> Text(
+            text = "시술 후 - 리뷰작성 전",
+            color = Color.Black,
+            fontSize = 15.sp
+        )
+
+        QuickCardType.AFTER_REVIEW -> Text(
+            text = "시술 후 - 리뷰작성 후",
+            color = Color.Black,
+            fontSize = 15.sp
+        )
+
+        QuickCardType.RE_RESERVATION_FEMALE -> Text(
+            text = "여성 재예약하기",
+            color = Color.Black,
+            fontSize = 15.sp
+        )
+
+        QuickCardType.RE_RESERVATION_MALE -> Text(
+            text = "남성 재예약하기",
+            color = Color.Black,
+            fontSize = 15.sp
+        )
+
+        QuickCardType.MY_DESIGNER -> Text(
+            text = "나의 단골 디자이너",
+            color = Color.Black,
+            fontSize = 15.sp
+        )
+
         QuickCardType.MY_MENU -> Text(text = "최근 본 메뉴", color = Color.Black, fontSize = 15.sp)
         QuickCardType.NORMAL -> Text(text = "프로필 업데이트", color = Color.Black, fontSize = 15.sp)
     }
@@ -160,7 +185,13 @@ fun ReservationCard() {
                     maxLines = 1
                 )
             }
-            Text(text = "D-5", fontSize = 15.sp, color = Color.White, modifier = Modifier.width(73.dp), textAlign = TextAlign.Center)
+            Text(
+                text = "D-5",
+                fontSize = 15.sp,
+                color = Color.White,
+                modifier = Modifier.width(73.dp),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }
@@ -186,7 +217,11 @@ fun DDayCard() {
                 modifier = Modifier.size(56.dp)
             )
             Spacer(modifier = Modifier.size(12.dp))
-            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = "여성 디자인컷",
@@ -203,7 +238,13 @@ fun DDayCard() {
                     maxLines = 1
                 )
             }
-            Text(text = "10:56:22", fontSize = 15.sp, color = Color.White, modifier = Modifier.width(73.dp), textAlign = TextAlign.Center)
+            Text(
+                text = "10:56:22",
+                fontSize = 15.sp,
+                color = Color.White,
+                modifier = Modifier.width(73.dp),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }
@@ -229,7 +270,11 @@ fun ReviewCard(isWrite: Boolean) {
                 modifier = Modifier.size(56.dp)
             )
             Spacer(modifier = Modifier.size(12.dp))
-            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = "여성 디자인컷",
@@ -246,9 +291,20 @@ fun ReviewCard(isWrite: Boolean) {
                     maxLines = 1
                 )
             }
-            Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.width(73.dp)) {
-                Image(painter = painterResource(id = R.drawable.ic_review), contentDescription = "리뷰 아이콘", modifier = Modifier.size(28.dp))
-                Text(text = if (isWrite) "리뷰 보기" else "리뷰 쓰기" , fontSize = 11.sp, color = Color.White)
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.width(73.dp)
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_review),
+                    contentDescription = "리뷰 아이콘",
+                    modifier = Modifier.size(28.dp)
+                )
+                Text(
+                    text = if (isWrite) "리뷰 보기" else "리뷰 쓰기",
+                    fontSize = 11.sp,
+                    color = Color.White
+                )
             }
         }
     }
@@ -278,7 +334,11 @@ fun ReReservationCard(isFemale: Boolean) {
                 modifier = Modifier.size(56.dp)
             )
             Spacer(modifier = Modifier.size(12.dp))
-            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = "여성 디자인컷",
@@ -302,12 +362,12 @@ fun ReReservationCard(isFemale: Boolean) {
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FavoriteCard(type: FavoriteType) {
-    val backgroundColor = when(type) {
+    val backgroundColor = when (type) {
         FavoriteType.DESIGNER -> 0xFFEA6062
         FavoriteType.MENU -> 0xFF4FABC9
     }
 
-    val message = when(type) {
+    val message = when (type) {
         FavoriteType.DESIGNER -> "나의 단골 디자이너"
         FavoriteType.MENU -> "여성 디자인컷"
     }
@@ -330,7 +390,11 @@ fun FavoriteCard(type: FavoriteType) {
                 modifier = Modifier.size(56.dp)
             )
             Spacer(modifier = Modifier.size(12.dp))
-            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(
                     text = message,
                     fontSize = 15.sp,
@@ -344,7 +408,11 @@ fun FavoriteCard(type: FavoriteType) {
                     maxLines = 1
                 )
             }
-            Image(painter = painterResource(id = R.drawable.ic_close), contentDescription = "리뷰 아이콘", modifier = Modifier.size(20.dp))
+            Image(
+                painter = painterResource(id = R.drawable.ic_close),
+                contentDescription = "리뷰 아이콘",
+                modifier = Modifier.size(20.dp)
+            )
         }
     }
 }
@@ -364,9 +432,18 @@ fun NormalCard() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Spacer(modifier = Modifier.height(56.dp))
-            Column(horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
+            Column(
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(text = "여성 디자인컷", fontSize = 15.sp, color = Color.White)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.basicMarquee(), maxLines = 1)
+                Text(
+                    text = "이수 수석 ・ 준오헤어 판교점",
+                    fontSize = 13.sp,
+                    color = Color.White,
+                    modifier = Modifier.basicMarquee(),
+                    maxLines = 1
+                )
             }
             Spacer(modifier = Modifier.weight(1f))
         }

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
@@ -15,9 +15,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -130,7 +130,7 @@ fun WelcomeCard() {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color.Yellow),
+        colors = ButtonDefaults.buttonColors(containerColor = Color.Yellow),
         onClick = {}
     ) {
         Row(
@@ -151,7 +151,7 @@ fun ReservationCard() {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFFF695B)),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF695B)),
         onClick = {}
     ) {
         Row(
@@ -204,7 +204,7 @@ fun DDayCard() {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFF666DC5)),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF666DC5)),
         onClick = {}
     ) {
         Row(
@@ -257,7 +257,7 @@ fun ReviewCard(isWrite: Boolean) {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFF888888)),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF888888)),
         onClick = {}
     ) {
         Row(
@@ -321,7 +321,7 @@ fun ReReservationCard(isFemale: Boolean) {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color(backgroundColor)),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(backgroundColor)),
         onClick = {}
     ) {
         Row(
@@ -377,7 +377,7 @@ fun FavoriteCard(type: FavoriteType) {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color(backgroundColor)),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(backgroundColor)),
         onClick = {}
     ) {
         Row(
@@ -425,7 +425,7 @@ fun NormalCard() {
             .fillMaxWidth()
             .padding(horizontal = 4.dp),
         shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFDDDDDD)),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFDDDDDD)),
         onClick = {}
     ) {
         Row(

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
@@ -1,9 +1,8 @@
 package com.example.compose_study.ui.screen.feature.component
 
-import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,17 +14,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -125,20 +118,9 @@ fun WelcomeCard() {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ReservationCard() {
-    val scrollState = rememberScrollState()
-    var animateState by remember { mutableStateOf(true) }
-
-    LaunchedEffect(key1 = animateState){
-        scrollState.animateScrollTo(
-            scrollState.maxValue,
-            animationSpec = tween(1000, 200, easing = CubicBezierEasing(0f,0f,0f,0f))
-        )
-        scrollState.scrollTo(0)
-        animateState = !animateState
-    }
-
     Button(
         modifier = Modifier
             .fillMaxWidth()
@@ -157,29 +139,35 @@ fun ReservationCard() {
                 modifier = Modifier.size(56.dp)
             )
             Spacer(modifier = Modifier.size(12.dp))
-            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
-                Text(text = "여성 디자인컷", fontSize = 15.sp, color = Color.White)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.horizontalScroll(scrollState, false), maxLines = 1)
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "여성 디자인컷",
+                    fontSize = 15.sp,
+                    color = Color.White
+                )
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(),
+                    text = "이수 수석 ・ 준오헤어 판교점",
+                    fontSize = 13.sp,
+                    color = Color.White,
+                    maxLines = 1
+                )
             }
             Text(text = "D-5", fontSize = 15.sp, color = Color.White, modifier = Modifier.width(73.dp), textAlign = TextAlign.Center)
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun DDayCard() {
-    val scrollState = rememberScrollState()
-    var animateState by remember { mutableStateOf(true) }
-
-    LaunchedEffect(key1 = animateState){
-        scrollState.animateScrollTo(
-            scrollState.maxValue,
-            animationSpec = tween(1000, 200, easing = CubicBezierEasing(0f,0f,0f,0f))
-        )
-        scrollState.scrollTo(0)
-        animateState = !animateState
-    }
-
     Button(
         modifier = Modifier
             .fillMaxWidth()
@@ -199,28 +187,30 @@ fun DDayCard() {
             )
             Spacer(modifier = Modifier.size(12.dp))
             Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
-                Text(text = "여성 디자인컷", fontSize = 15.sp, color = Color.White)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.horizontalScroll(scrollState, false), maxLines = 1)
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "여성 디자인컷",
+                    fontSize = 15.sp,
+                    color = Color.White
+                )
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(),
+                    text = "이수 수석 ・ 준오헤어 판교점",
+                    fontSize = 13.sp,
+                    color = Color.White,
+                    maxLines = 1
+                )
             }
             Text(text = "10:56:22", fontSize = 15.sp, color = Color.White, modifier = Modifier.width(73.dp), textAlign = TextAlign.Center)
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ReviewCard(isWrite: Boolean) {
-    val scrollState = rememberScrollState()
-    var animateState by remember { mutableStateOf(true) }
-
-    LaunchedEffect(key1 = animateState){
-        scrollState.animateScrollTo(
-            scrollState.maxValue,
-            animationSpec = tween(1000, 200, easing = CubicBezierEasing(0f,0f,0f,0f))
-        )
-        scrollState.scrollTo(0)
-        animateState = !animateState
-    }
-
     Button(
         modifier = Modifier
             .fillMaxWidth()
@@ -240,8 +230,21 @@ fun ReviewCard(isWrite: Boolean) {
             )
             Spacer(modifier = Modifier.size(12.dp))
             Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
-                Text(text = "여성 디자인컷", fontSize = 15.sp, color = Color.White)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.horizontalScroll(scrollState, false), maxLines = 1)
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "여성 디자인컷",
+                    fontSize = 15.sp,
+                    color = Color.White
+                )
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(),
+                    text = "이수 수석 ・ 준오헤어 판교점",
+                    fontSize = 13.sp,
+                    color = Color.White,
+                    maxLines = 1
+                )
             }
             Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.width(73.dp)) {
                 Image(painter = painterResource(id = R.drawable.ic_review), contentDescription = "리뷰 아이콘", modifier = Modifier.size(28.dp))
@@ -251,20 +254,9 @@ fun ReviewCard(isWrite: Boolean) {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ReReservationCard(isFemale: Boolean) {
-    val scrollState = rememberScrollState()
-    var animateState by remember { mutableStateOf(true) }
-
-    LaunchedEffect(key1 = animateState){
-        scrollState.animateScrollTo(
-            scrollState.maxValue,
-            animationSpec = tween(1000, 200, easing = CubicBezierEasing(0f,0f,0f,0f))
-        )
-        scrollState.scrollTo(0)
-        animateState = !animateState
-    }
-
     val backgroundColor = if (isFemale) 0xFFFFA05B else 0xFF74E0C7
     val message = if (isFemale) "줄리님 스타일 손볼 때 되셨네요!" else "랄프님 머리할 때 되셨네요!"
 
@@ -287,27 +279,29 @@ fun ReReservationCard(isFemale: Boolean) {
             )
             Spacer(modifier = Modifier.size(12.dp))
             Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
-                Text(text = message, fontSize = 15.sp, color = Color.Black)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.Black, modifier = Modifier.horizontalScroll(scrollState, false), maxLines = 1)
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "여성 디자인컷",
+                    fontSize = 15.sp,
+                    color = Color.Black
+                )
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(),
+                    text = "이수 수석 ・ 준오헤어 판교점",
+                    fontSize = 13.sp,
+                    color = Color.Black,
+                    maxLines = 1
+                )
             }
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FavoriteCard(type: FavoriteType) {
-    val scrollState = rememberScrollState()
-    var animateState by remember { mutableStateOf(true) }
-
-    LaunchedEffect(key1 = animateState){
-        scrollState.animateScrollTo(
-            scrollState.maxValue,
-            animationSpec = tween(1000, 200, easing = CubicBezierEasing(0f,0f,0f,0f))
-        )
-        scrollState.scrollTo(0)
-        animateState = !animateState
-    }
-
     val backgroundColor = when(type) {
         FavoriteType.DESIGNER -> 0xFFEA6062
         FavoriteType.MENU -> 0xFF4FABC9
@@ -337,28 +331,27 @@ fun FavoriteCard(type: FavoriteType) {
             )
             Spacer(modifier = Modifier.size(12.dp))
             Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
-                Text(text = message, fontSize = 15.sp, color = Color.White)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.horizontalScroll(scrollState, false), maxLines = 1)
+                Text(
+                    text = message,
+                    fontSize = 15.sp,
+                    color = Color.White
+                )
+                Text(
+                    text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(),
+                    maxLines = 1
+                )
             }
             Image(painter = painterResource(id = R.drawable.ic_close), contentDescription = "리뷰 아이콘", modifier = Modifier.size(20.dp))
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NormalCard() {
-    val scrollState = rememberScrollState()
-    var animateState by remember { mutableStateOf(true) }
-
-    LaunchedEffect(key1 = animateState){
-        scrollState.animateScrollTo(
-            scrollState.maxValue,
-            animationSpec = tween(1000, 200, easing = CubicBezierEasing(0f,0f,0f,0f))
-        )
-        scrollState.scrollTo(0)
-        animateState = !animateState
-    }
-
     Button(
         modifier = Modifier
             .fillMaxWidth()
@@ -373,7 +366,7 @@ fun NormalCard() {
             Spacer(modifier = Modifier.height(56.dp))
             Column(horizontalAlignment = Alignment.Start, verticalArrangement = Arrangement.Center) {
                 Text(text = "여성 디자인컷", fontSize = 15.sp, color = Color.White)
-                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.horizontalScroll(scrollState, false), maxLines = 1)
+                Text(text = "이수 수석 ・ 준오헤어 판교점", fontSize = 13.sp, color = Color.White, modifier = Modifier.basicMarquee(), maxLines = 1)
             }
             Spacer(modifier = Modifier.weight(1f))
         }
@@ -390,12 +383,3 @@ enum class QuickCardType {
 enum class FavoriteType {
     DESIGNER, MENU
 }
-
-//@OptIn(ExperimentalPagerApi::class)
-//@Preview
-//@Composable
-//fun UserCardPreview() {
-//    Compose_studyTheme {
-//        QuickCardScreen()
-//    }
-//}

--- a/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
+++ b/app/src/main/java/com/example/compose_study/ui/screen/feature/component/QuickCards.kt
@@ -1,10 +1,15 @@
 package com.example.compose_study.ui.screen.feature.component
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -44,12 +48,7 @@ fun QuickCardScreen(
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
-        Box(
-            modifier = Modifier.padding(horizontal = 16.dp)
-        ) {
-            CardMessage(quickCards[state.currentPage])
-        }
-        Spacer(modifier = Modifier.size(16.dp))
+        WelcomeMessage(quickCards[state.currentPage])
         HorizontalPager(
             state = state,
             count = quickCards.size,
@@ -80,6 +79,28 @@ fun QuickCard(type: QuickCardType) {
         QuickCardType.MY_DESIGNER -> FavoriteCard(FavoriteType.DESIGNER)
         QuickCardType.MY_MENU -> FavoriteCard(FavoriteType.MENU)
         QuickCardType.NORMAL -> NormalCard()
+    }
+}
+
+@Composable
+fun WelcomeMessage(
+    type: QuickCardType
+) {
+    val animationDurationMillis = 1500
+    AnimatedContent(
+        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+        targetState = type,
+        transitionSpec = {
+            (fadeIn(animationSpec = tween(durationMillis = animationDurationMillis)) +
+                    slideInVertically(
+                        initialOffsetY = { 40.dp.value.toInt() },
+                        animationSpec = tween(animationDurationMillis)
+                    )
+                    ).togetherWith(fadeOut(animationSpec = tween(durationMillis = 0)))
+        },
+        label = ""
+    ) { currentType ->
+        CardMessage(type = currentType)
     }
 }
 


### PR DESCRIPTION
### 작업 내용
1. Feature > 설명부분 basicMarque() 적용
2. Feature > Message 부분 fadeIn + slideInVertically 적용
3. Feature > PersonalCard material3로 수정

### 작업 화면

https://github.com/Gyuil-Hwnag/compose_study/assets/84956038/07f40474-9610-4d70-9312-4e36ff5186b8

### 참고사항
- 애니메이션의 경우 `AnimatedVisible`, `Crossfade`, `AnimatedContent`중에 고민을 하였으나, 아래등의 이슈로 최종 `AnimatedContent`선정

1. `AnimatedVisible` 
-  visible을 트리거로 동작을 하게 되는데, 이로 인하여 visible을 컨트롤 하기 위한 Delay 부분이 들어가게 되며, 이로 인하여 연속 스와이프를 하는 경우 visible = false로 인하여 공간이 Column 에서 사라지게 됨.

2. `Crossfade`
- `Crossfade`의 경우 `AnimatedContent`와 동일하게 `targetState`를 통해서 애니메이션을 트리거할 수 있으나 단순 fadeIn, fadeOut 에는 적합하며, slideInVertically 애니메이션의 추가가 어려움

3. `AnimatedContent`
- 트리거가 `targetState`이며, 애니메이션에 대한 추가도 간편하여 최종적으로 선택