### PR TITLE
[FlowExt] Rxjava 의 takeUntil 함수를 Flow Extenions 로 추가

### DIFF
--- a/app/src/main/java/com/example/compose_study/utils/FlowExt.kt
+++ b/app/src/main/java/com/example/compose_study/utils/FlowExt.kt
@@ -1,0 +1,52 @@
+package com.example.compose_study.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+
+// Rxjava 의 takeUntil 함수와 같은 동작을 함.
+fun <T> Flow<T>.takeUntil(predicate: (T) -> Boolean): Flow<T> = flow {
+    this@takeUntil.collect { value ->
+        emit(value)
+        if (predicate(value)) {
+            currentCoroutineContext().cancel()
+        }
+    }
+}
+
+class FlowExt {
+    private suspend fun collect1() {
+        flowTest1.takeUntil { it == 10 }
+            .collect {
+                delay(10)
+                println("takeUntil : $it")
+            }
+    }
+
+    private suspend fun collect2() {
+        flowTest2.collect {
+            delay(10)
+            println("collect : $it")
+        }
+    }
+
+    fun invoke() {
+        CoroutineScope(Dispatchers.Main).launch {
+            // 10 까지 방출 후 종료
+            launch { collect1() }
+            // collect1이 종료된 후에도 방출 하여 100 까지 모두 방출
+            launch { collect2() }
+        }
+    }
+
+    companion object {
+        private val flowTest1 = (0 until 100).asFlow()
+        private val flowTest2 = (0 until 100).asFlow()
+    }
+}


### PR DESCRIPTION
### 작업내용

RxJava 에서 지원하는 `takeUntil` 함수는 Flow 에서는 지원을 하지 않는다.
RxJava 에서 Flow 로 마이그레이션을 할때 비슷한 기능을 하도록 Flow 의 Extenions 함수를 만들어 보자.

### 참고사항

- RxJava 의 `takeUntil` 은 아래와 같이 해당 조건이 충족할 경우 `onComplete`로 해당값을 방출하고 종료한다.

![image](https://github.com/user-attachments/assets/bfb8cc9b-2171-408c-be41-345d8c5d09a7)

- Flow 에서는 `takeUntil`을 지원하지 않고 있으며, `cancelable Job` 이라는 특성을 이용하여, 해당 조건 충족시 Job 을 종료한다면, Rx의 `takeUntil`과 같은 동작을 하도록 구현이 가능해진다.
~~~kotlin
fun <T> Flow<T>.takeUntil(predicate: (T) -> Boolean): Flow<T> = flow {
    this@takeUntil.collect { value ->
        emit(value)
        if (predicate(value)) {
            currentCoroutineContext().cancel()
        }
    }
}
~~~